### PR TITLE
Remove caniuse-lite schedule from default.json

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,14 +29,6 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "devDependencies non-major"
-    },
-    {
-      "packageNames": [
-        "caniuse-lite"
-      ],
-      "schedule": [
-        "on the 1st day instance on sunday after 3:15am"
-      ]
     }
   ],
   "patch": {


### PR DESCRIPTION
Removed specific schedule for caniuse-lite package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated dependency management configuration by removing redundant package rules, streamlining the scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->