### PR TITLE
fix: dedupe yarn lockfiles after renovate updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -38,6 +38,7 @@
   "patch": {
     "automerge": true
   },
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "rebaseStalePrs": true,
   "schedule": [
     "on the 1st and 3rd day instance on saturday after 3:15am",


### PR DESCRIPTION
## Why

When Renovate bumps a pinned dependency, Yarn only adds new lockfile entries — it never revisits existing ones. Semver ranges declared by transitive dependencies stay locked on their old resolutions, so lockfiles silently accumulate duplicate versions of the same packages. Since patch/minor updates automerge, this lands on master without review.

This broke all `connect` deployments on 2026-07-20: the `aws-sdk-js-v3 → 3.1090.0` bump duplicated the entire `@aws-sdk`/`@smithy` tree (ranges from `@allthings/cloud-toolkit` stayed locked on 3.1079), doubling the Lambda dependencies layer from 151 MB to 300 MB — over Lambda's 250 MB unzipped limit. Fixed for connect in allthings/connect#798; this PR prevents the same class of problem org-wide.

## What

`postUpdateOptions: ["yarnDedupeHighest"]` makes Renovate run `yarn dedupe --strategy highest` (Yarn Berry) / `yarn-deduplicate` (Yarn 1) after every lockfile update, so Renovate PRs arrive pre-deduped.

- Pure consolidation: ranges are re-pointed at the highest version **already in the lockfile** — no new versions are fetched.
- Safe org-wide: silently ignored in repos without a JS lockfile.
- Complements (doesn't replace) the existing monthly `lockFileMaintenance`, which only cleans up duplication weeks after it appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency updates by deduplicating packages to the highest compatible versions after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->